### PR TITLE
[Delivers #49344721 Fix Volume - Attachment property to resolve serialization issues

### DIFF
--- a/src/corelib/Core/Domain/Volume.cs
+++ b/src/corelib/Core/Domain/Volume.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Runtime.Serialization;
 
 namespace net.openstack.Core.Domain
@@ -25,7 +26,7 @@ namespace net.openstack.Core.Domain
         public string SnapshotId { get; set; }
 
         [DataMember]
-        public string[] Attachments { get; set; }
+        public Dictionary<string, string>[] Attachments { get; set; }
 
         [DataMember]
         public string Status { get; set; }


### PR DESCRIPTION
**Summary**
This will resolve an issue for the Cloud Block Storage provider when it is attempting to serialize the volume object's "Attachments" property.  Currently the "Attachments" property is currently set as a string array and it needs to be a dictionary<string,string> to be able to handle what is being sent from the API correctly.

**Testing**
Ran full integration tests and all passed.
