### PR TITLE
Object copy requires a "Content-Length: 0" in the request

### DIFF
--- a/src/corelib/Providers/Rackspace/CloudFilesProvider.cs
+++ b/src/corelib/Providers/Rackspace/CloudFilesProvider.cs
@@ -664,7 +664,7 @@ namespace net.openstack.Providers.Rackspace
                 headers = new Dictionary<string, string>();
             }
 
-            headers.Add(ContentLength, 0)
+            headers.Add(ContentLength, 0);
             headers.Add(CopyFrom, string.Format("{0}/{1}", sourceContainer, sourceObjectName));
 
             var urlPath = new Uri(string.Format("{0}/{1}/{2}", GetServiceEndpointCloudFiles(identity, region, useInternalUrl), _encodeDecodeProvider.UrlEncode(destinationContainer), _encodeDecodeProvider.UrlEncode(destinationObjectName)));


### PR DESCRIPTION
As per the RAX API docs for Cloud Files, object copy requests via a PUT need the content length specified to be zero:

http://docs.rackspace.com/files/api/v1/cf-devguide/content/Copy_Object-d1e2241.html

I have modified the relevant section to check only if the header has been defined and create the new dictionary if not.  The content length is explicitly provided in an add call.
