### PR TITLE
Added the functionality to delete file segments if they exist

### DIFF
--- a/src/corelib/Core/Providers/IObjectStorageProvider.cs
+++ b/src/corelib/Core/Providers/IObjectStorageProvider.cs
@@ -358,11 +358,12 @@ namespace net.openstack.Core.Providers
         /// <param name="container">The container name.</param>
         /// <param name="objectName">Name of the object.<remarks>Example image_name.jpeg</remarks></param>
         /// <param name="headers">A list of HTTP headers to send to the service. </param>
+        /// <param name="deleteSegments">Indicates whether the file's segments should be deleted if any exist.</param>
         /// <param name="region">The region in which to execute this action.<remarks>If not specified, the user’s default region will be used.</remarks></param>
         /// <param name="useInternalUrl">If set to <c>true</c> uses ServiceNet URL.</param>
         /// <param name="identity">The users Cloud Identity. <see cref="CloudIdentity"/> <remarks>If not specified, the default identity given in the constructor will be used.</remarks> </param>
         /// <returns><see cref="ObjectStore"/></returns>
-        ObjectStore DeleteObject(string container, string objectName, Dictionary<string, string> headers = null, string region = null, bool useInternalUrl = false, CloudIdentity identity = null);
+        ObjectStore DeleteObject(string container, string objectName, Dictionary<string, string> headers = null, bool deleteSegments = true, string region = null, bool useInternalUrl = false, CloudIdentity identity = null);
 
         /// <summary>
         /// Purges the object from CDN.

--- a/src/testing/integration/Providers/Rackspace/CloudFilesTests.cs
+++ b/src/testing/integration/Providers/Rackspace/CloudFilesTests.cs
@@ -719,6 +719,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
             Assert.AreEqual(sourceheader.First(h => h.Key.Equals("Content-Length", StringComparison.OrdinalIgnoreCase)).Value, destinationHeader.First(h => h.Key.Equals("Content-Length", StringComparison.OrdinalIgnoreCase)).Value);
 
         }
+
         [TestMethod]
         public void Should_Get_MetaData_For_Object1()
         {


### PR DESCRIPTION
### Changes
- Modified the `CloudFilesProvider.DeleteObject` logic to check to see if the file is being deleted is a manifest file.  If so, then it retrieves all the files in the manifests and deletes them as well.
- Fixed a bug in the `CloudFilesProvider` that caused the token to be re-fetched each time a web request was made to the service.
- Removed unused constants from the `CloudFilesProvider` class
