### PR TITLE
Fix duplicate key exception on API 401 response

### DIFF
--- a/src/corelib/Providers/Rackspace/ProviderBase.cs
+++ b/src/corelib/Providers/Rackspace/ProviderBase.cs
@@ -78,10 +78,10 @@ namespace net.openstack.Providers.Rackspace
             if (headers == null)
                 headers = new Dictionary<string, string>();
 
-            if (!headers.ContainsKey("X-Auth-Token"))
-            {
-                headers.Add("X-Auth-Token", IdentityProvider.GetToken(identity, isRetry));
-            }
+            if (headers.ContainsKey("X-Auth-Token"))
+                headers.Remove("X-Auth-Token");
+
+            headers.Add("X-Auth-Token", IdentityProvider.GetToken(identity, isRetry));
 
             string bodyStr = null;
             if (body != null)
@@ -125,10 +125,10 @@ namespace net.openstack.Providers.Rackspace
             if (headers == null)
                 headers = new Dictionary<string, string>();
 
-            if (!headers.ContainsKey("X-Auth-Token"))
-            {
-                headers.Add("X-Auth-Token", IdentityProvider.GetToken(identity, isRetry));
-            }
+            if (headers.ContainsKey("X-Auth-Token"))
+                headers.Remove("X-Auth-Token");
+
+            headers.Add("X-Auth-Token", IdentityProvider.GetToken(identity, isRetry));
 
             if (string.IsNullOrWhiteSpace(requestSettings.UserAgent))
                 requestSettings.UserAgent = GetUserAgentHeaderValue();


### PR DESCRIPTION
If an API response status is 401, we retry 1 time and send the current headers. On the 2nd attempt, we do not check if the X-Auth-Token exists which causes an "An item with the same key has already been added." exception.
