### PR TITLE
Improve messages in exceptions

### DIFF
--- a/src/corelib/Core/Exceptions/Response/ResponseException.cs
+++ b/src/corelib/Core/Exceptions/Response/ResponseException.cs
@@ -1,4 +1,8 @@
 using System;
+using System.Net;
+using System.Runtime.Serialization;
+using JSIStudios.SimpleRESTServices.Client.Json;
+using Newtonsoft.Json;
 
 namespace net.openstack.Core.Exceptions.Response
 {
@@ -10,6 +14,98 @@ namespace net.openstack.Core.Exceptions.Response
             : base(message)
         {
             Response = response;
+        }
+
+        /// <inheritdoc/>
+        public override string Message
+        {
+            get
+            {
+                if (Response != null && Response.HasJsonBody())
+                {
+                    try
+                    {
+                        ErrorResponse response = JsonConvert.DeserializeObject<ErrorResponse>(Response.RawBody);
+                        if (!string.IsNullOrEmpty(response.Message))
+                            return response.Message;
+                    }
+                    catch (JsonSerializationException)
+                    {
+                        // will fall back to base.Message
+                    }
+                }
+
+                return base.Message;
+            }
+        }
+
+        [Serializable]
+        private sealed class ErrorResponse : ISerializable
+        {
+            private readonly string _errorKind;
+            private readonly ErrorDetails _errorDetails;
+
+            private ErrorResponse(SerializationInfo info, StreamingContext context)
+            {
+                if (info.MemberCount != 1)
+                    throw new ArgumentException();
+
+                foreach (SerializationEntry entry in info)
+                {
+                    _errorKind = entry.Name;
+                    _errorDetails = JsonConvert.DeserializeObject<ErrorDetails>(entry.Value.ToString());
+                }
+            }
+
+            public string ErrorKind
+            {
+                get
+                {
+                    return _errorKind;
+                }
+            }
+
+            public int Code
+            {
+                get
+                {
+                    return _errorDetails.Code;
+                }
+            }
+
+            public string Message
+            {
+                get
+                {
+                    return _errorDetails.Message;
+                }
+            }
+
+            public string Details
+            {
+                get
+                {
+                    return _errorDetails.Details;
+                }
+            }
+
+            void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        [DataContract]
+        private sealed class ErrorDetails
+        {
+            [DataMember(Name = "code")]
+            public int Code;
+
+            [DataMember(Name = "message")]
+            public string Message;
+
+            [DataMember(Name = "details")]
+            public string Details;
         }
     }
 }

--- a/src/corelib/Core/ResponseExtensions.cs
+++ b/src/corelib/Core/ResponseExtensions.cs
@@ -1,0 +1,84 @@
+﻿namespace net.openstack.Core
+{
+    using System;
+    using System.Linq;
+    using System.Net;
+    using JSIStudios.SimpleRESTServices.Client;
+    using JSIStudios.SimpleRESTServices.Client.Json;
+
+    /// <summary>
+    /// Contains extension methods to the <see cref="Response"/> class.
+    /// </summary>
+    internal static class ResponseExtensions
+    {
+        /// <summary>
+        /// The content type used for standard JSON requests and responses.
+        /// </summary>
+        private static readonly string JsonContentType = new JsonRequestSettings().ContentType;
+
+        /// <summary>
+        /// Retrieves a standard HTTP response header from a REST response, if available.
+        /// </summary>
+        /// <param name="response">The REST response.</param>
+        /// <param name="header">The header to retrieve.</param>
+        /// <param name="value">Returns the value for <paramref name="header"/>.</param>
+        /// <returns><c>true</c> if the specified header is contained in <paramref name="response"/>, otherwise <c>false</c>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="response"/> is <c>null</c>.</exception>
+        public static bool TryGetHeader(this Response response, HttpResponseHeader header, out string value)
+        {
+            if (response == null)
+                throw new ArgumentNullException("response");
+
+            if (response.Headers == null)
+            {
+                value = null;
+                return false;
+            }
+
+            WebHeaderCollection collection = new RestWebHeaderCollection(response.Headers);
+            value = collection[header];
+            return value != null;
+        }
+
+        /// <summary>
+        /// Retrieves a custom HTTP response header from a REST response, if available.
+        /// </summary>
+        /// <param name="response">The REST response.</param>
+        /// <param name="header">The header to retrieve.</param>
+        /// <param name="value">Returns the value for <paramref name="header"/>.</param>
+        /// <returns><c>true</c> if the specified header is contained in <paramref name="response"/>, otherwise <c>false</c>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="response"/> is <c>null</c>.</exception>
+        public static bool TryGetHeader(this Response response, string header, out string value)
+        {
+            HttpHeader httpHeader = response.Headers.FirstOrDefault(i => string.Equals(i.Key, header, StringComparison.OrdinalIgnoreCase));
+            value = httpHeader != null ? httpHeader.Value : null;
+            return value != null;
+        }
+
+        /// <summary>
+        /// This method checks if a REST <see cref="Response"/> contains a JSON-formatted body.
+        /// The response is assumed to be JSON if the content type is reported as <c>application/json</c>
+        /// and the body is not empty.
+        /// </summary>
+        /// <param name="response">The REST response.</param>
+        /// <returns><c>true</c> if <paramref name="response"/> contains a JSON response body, otherwise <c>false</c>.</returns>
+        public static bool HasJsonBody(this Response response)
+        {
+            if (response == null)
+                throw new ArgumentNullException("response");
+
+            string contentTypeHeader;
+            if (response.TryGetHeader(HttpResponseHeader.ContentType, out contentTypeHeader))
+            {
+                // ignore optional parameters when checking the content type
+                string contentType = contentTypeHeader.Split(';')[0].Trim();
+                if (string.Equals(contentType, JsonContentType, StringComparison.OrdinalIgnoreCase))
+                {
+                    return !string.IsNullOrEmpty(response.RawBody);
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/corelib/Core/RestWebHeaderCollection.cs
+++ b/src/corelib/Core/RestWebHeaderCollection.cs
@@ -1,0 +1,82 @@
+﻿namespace net.openstack.Core
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net;
+    using System.Runtime.Serialization;
+    using JSIStudios.SimpleRESTServices.Client;
+
+    /// <summary>
+    /// Contains protocol headers associated with a REST request or response.
+    /// </summary>
+    /// <remarks>
+    /// This collection does restrict headers which are exposed through properties,
+    /// allowing users to explicitly construct a complete set of headers.
+    /// </remarks>
+    [Serializable]
+    public class RestWebHeaderCollection : WebHeaderCollection
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RestWebHeaderCollection"/> class.
+        /// </summary>
+        public RestWebHeaderCollection()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RestWebHeaderCollection"/> class from
+        /// the specified headers.
+        /// </summary>
+        /// <param name="headers">The headers to initially add to this collection.</param>
+        /// <exception cref="ArgumentException">
+        /// A header name is <c>null</c>, <see cref="string.Empty"/>, or contains invalid characters.
+        /// <para>-or-</para>
+        /// <para>A header value contains invalid characters.</para>
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">A header contains a value longer than 65535 characters.</exception>
+        public RestWebHeaderCollection(IEnumerable<HttpHeader> headers)
+        {
+            foreach (HttpHeader header in headers)
+                Add(header.Key, header.Value);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RestWebHeaderCollection"/> class from the specified
+        /// instances of the <see cref="SerializationInfo"/> and <see cref="StreamingContext"/> classes.
+        /// </summary>
+        /// <param name="info">A <see cref="SerializationInfo"/> containing the information required to serialize the <see cref="RestWebHeaderCollection"/>.</param>
+        /// <param name="context">A <see cref="StreamingContext"/> containing the source of the serialized stream associated with the new <see cref="RestWebHeaderCollection"/>.</param>
+        /// <remarks>
+        /// This constructor implements the <see cref="ISerializable"/> interface for the <see cref="RestWebHeaderCollection"/> class.
+        /// </remarks>
+        /// <exception cref="ArgumentException"><paramref name="headerName"/> contains invalid characters.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="headerName"/> is a null reference or <see cref="string.Empty"/>.</exception>
+        protected RestWebHeaderCollection(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+
+        /// <summary>
+        /// Inserts a header with the specified name and value into the collection.
+        /// </summary>
+        /// <remarks>
+        /// If the header specified in <paramref name="name"/> does not exist, the <see cref="Add"/> method
+        /// inserts a new header into the list of header name/value pairs.
+        ///
+        /// <para>If the header specified in <paramref name="name"/> is already present, <paramref name="value"/>
+        /// is added to the existing comma-separated list of values associated with <paramref name="name"/>.</para>
+        /// </remarks>
+        /// <param name="name">The header to add to the collection.</param>
+        /// <param name="value">The content of the header.</param>
+        /// <exception cref="ArgumentException">
+        /// A <paramref name="name"/> is <c>null</c>, <see cref="string.Empty"/>, or contains invalid characters.
+        /// <para>-or-</para>
+        /// <para>A <paramref name="value"/> contains invalid characters.</para>
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">The length of <paramref name="value"/> is greater than 65535.</exception>
+        public override void Add(string name, string value)
+        {
+            AddWithoutValidate(name, value);
+        }
+    }
+}

--- a/src/corelib/corelib.csproj
+++ b/src/corelib/corelib.csproj
@@ -65,6 +65,8 @@
     <Compile Include="Core\Domain\ContainerObject.cs" />
     <Compile Include="Core\Domain\Flavor.cs" />
     <Compile Include="Core\Domain\FlavorDetails.cs" />
+    <Compile Include="Core\ResponseExtensions.cs" />
+    <Compile Include="Core\RestWebHeaderCollection.cs" />
     <Compile Include="Providers\Rackspace\Exceptions\BulkDeletionException.cs" />
     <Compile Include="Core\HttpStatusCodeParser.cs" />
     <Compile Include="Core\IStatusParser.cs" />


### PR DESCRIPTION
Some APIs return additional exception information in a known format. When this occurs, the message provided by the server is used for the exception that gets thrown. If the returned value could not be parsed in the known format, the default exception message for the HTTP status code is used.

The implementation of this feature includes two new classes which can be reused:
- `ResponseExtensions`: Provides the `TryGetHeader` extension method to get a header specified by the `HttpResponseHeaders` enumeration without requiring the developer to include the string literal representation of the header key
- `RestWebHeaderCollection`: Extends `WebHeaderCollection` by _not_ treating particular headers (e.g. `Content-Type`) as reserved (see the documentation for [`WebHeaderCollection`](http://msdn.microsoft.com/en-us/library/system.net.webheadercollection.aspx) for additional details).
