### PR TITLE
Add support for prefix in ListObjects for CloudFiles provider

### DIFF
--- a/src/corelib/Core/Providers/IObjectStorageProvider.cs
+++ b/src/corelib/Core/Providers/IObjectStorageProvider.cs
@@ -316,11 +316,12 @@ namespace net.openstack.Core.Providers
         /// <param name="limit">The limit.</param>
         /// <param name="marker">The marker.</param>
         /// <param name="markerEnd">The marker end.</param>
+        /// <param name="prefix">Prefix of object names to include</param>
         /// <param name="region">The region in which to execute this action.<remarks>If not specified, the user’s default region will be used.</remarks></param>
         /// <param name="useInternalUrl">If set to <c>true</c> uses ServiceNet URL.</param>
         /// <param name="identity">The users Cloud Identity. <see cref="CloudIdentity"/> <remarks>If not specified, the default identity given in the constructor will be used.</remarks> </param>
         /// <returns>IEnumerable of <see cref="net.openstack.Core.Domain.ContainerObject"/></returns>
-        IEnumerable<ContainerObject> ListObjects(string container, int? limit = null, string marker = null, string markerEnd = null, string region = null, bool useInternalUrl = false, CloudIdentity identity = null, string prefix = null);
+        IEnumerable<ContainerObject> ListObjects(string container, int? limit = null, string marker = null, string markerEnd = null, string prefix = null, string region = null, bool useInternalUrl = false, CloudIdentity identity = null);
 
         /// <summary>
         /// Creates the object from file.

--- a/src/corelib/Providers/Rackspace/CloudFilesProvider.cs
+++ b/src/corelib/Providers/Rackspace/CloudFilesProvider.cs
@@ -648,7 +648,7 @@ namespace net.openstack.Providers.Rackspace
         }
 
         /// <inheritdoc />
-        public IEnumerable<ContainerObject> ListObjects(string container, int? limit = null, string marker = null, string markerEnd = null, string region = null, bool useInternalUrl = false, CloudIdentity identity = null, string prefix = null)
+        public IEnumerable<ContainerObject> ListObjects(string container, int? limit = null, string marker = null, string markerEnd = null,  string prefix = null, string region = null, bool useInternalUrl = false, CloudIdentity identity = null)
         {
             _cloudFilesValidator.ValidateContainerName(container);
             var urlPath = new Uri(string.Format("{0}/{1}", GetServiceEndpointCloudFiles(identity, region, useInternalUrl), _encodeDecodeProvider.UrlEncode(container)));


### PR DESCRIPTION
The current ListObjects doesn't support the prefix parameter. This adds support.
