### PR TITLE
re-adding functionality to add virtual interfaces to CloudServers at cre...

### DIFF
--- a/src/corelib/Providers/Rackspace/CloudServersProvider.cs
+++ b/src/corelib/Providers/Rackspace/CloudServersProvider.cs
@@ -203,6 +203,9 @@ namespace net.openstack.Providers.Rackspace
                     networksToAttach.Add("11111111-1111-1111-1111-111111111111");
             }
 
+            if (networks != null && networks.Any())
+                networksToAttach.AddRange(networks.Select(guid => guid.ToString()));
+
             const string accessIPv4 = null;
             const string accessIPv6 = null;
             var request = new CreateServerRequest(cloudServerName, imageName, flavor, diskConfig, metadata, accessIPv4, accessIPv6, networksToAttach, personality);


### PR DESCRIPTION
...ation time.

Hey guys,

while writing a Console App utilizing the CloudServersProvider.CreateServer method I noticed that additional Cloud Networks passed via `IEnumerable<Guid> networks` do not get attached to the server. It seems like this functionality has been removed accidentally during commit 0c61082.

I wasn't sure whether I had to run the unit tests before issuing the pull request (or even how to run them :smile:). I did however test this in my App and it worked fine. Let me know if I have to run any other tests first and how to do so.

Thanks
Nico 
